### PR TITLE
Fix crash with TIAB mod

### DIFF
--- a/common/src/main/java/net/satisfy/herbalbrews/core/blocks/entity/TeaLeafBlockEntity.java
+++ b/common/src/main/java/net/satisfy/herbalbrews/core/blocks/entity/TeaLeafBlockEntity.java
@@ -58,6 +58,9 @@ public class TeaLeafBlockEntity extends BlockEntity implements BlockEntityTicker
 
         if (timer >= dryingDuration) {
             BlockState state = level.getBlockState(blockPos);
+            if(!state.hasProperty(TeaLeafBlock.DRYING))
+                return;
+
             int dryingStage = state.getValue(TeaLeafBlock.DRYING);
             if (dryingStage < 4) {
                 level.levelEvent(2001, blockPos, Block.getId(state));


### PR DESCRIPTION
Fix crash where the tea leaf block entity would check its drying state after being transformed into a dried tea leaf.
Which would lead to this crash:
```
java.lang.IllegalArgumentException: Cannot get property IntegerProperty{name=drying, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4]} as it does not exist in Block{herbalbrews:dried_out_green_tea_leaf_block}
	at net.minecraft.world.level.block.state.StateHolder.m_61143_(StateHolder.java:98) ~[server-1.20.1-20230612.114412-srg.jar%231011!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:computing_frames,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:ferritecore.fastmap.mixin.json:FastMapStateHolderMixin from mod ferritecore,pl:mixin:APP:create.mixins.json:accessor.StateHolderAccessor from mod create,pl:mixin:A,pl:connector_pre_launch:A}
	at net.satisfy.herbalbrews.core.blocks.entity.TeaLeafBlockEntity.tick(TeaLeafBlockEntity.java:61) ~[letsdo-herbalbrews-forge-1.0.12.jar%23816!/:?] {re:classloading}
	at net.satisfy.herbalbrews.core.blocks.TeaLeafBlock.lambda$getTicker$0(TeaLeafBlock.java:40) ~[letsdo-herbalbrews-forge-1.0.12.jar%23816!/:?] {re:classloading}
```

On another note, this issue might be related to how the TIAB mod accelerate block entity ticking.